### PR TITLE
Moved the hashed filename creation after the CSS is transformed/replaced

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -184,16 +184,22 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
         // NOTE: We can't minify with cleanCSS because it has so many inconsistencies and invalid optimizations
         var minify = results;
 
+        var fileNameParts = fileName.split('.')
+            , hash = crypto.createHash('md5').update(minify)
+            , hashedFileName = fileNameParts.slice(0, -1).join('.')
+              + '.' + hash.digest('hex')
+              + '.' + fileNameParts.pop();
+
         zlib.gzip(minify, function(err, buffer) {
           if (err) throwError(err);
-          S3.putGzipBuffer(buffer, encodeURIComponent(fileName), headers, function(err, response) {
+          S3.putGzipBuffer(buffer, encodeURIComponent(hashedFileName), headers, function(err, response) {
             if (err) throwError(err);
             if (response.statusCode !== 200) {
               //throwError('unsuccessful upload of stylesheet "' + fileName + '" to S3');
-              console.log('unsuccessful upload of stylesheet "' + fileName + '" to S3');
+              console.log('unsuccessful upload of stylesheet "' + hashedFileName + '" to S3');
               return finishUpload();
             } else {
-              logger({ task: 'express-cdn', message: 'successfully uploaded stylesheet "' + fileName + '" to S3' });
+              logger({ task: 'express-cdn', message: 'successfully uploaded stylesheet "' + hashedFileName + '" to S3' });
               return finishUpload();
             }
           });
@@ -460,12 +466,20 @@ var processAssets = function(options, results, done) {
       S3.headFile(encodeURIComponent(fileName), checkArrayIfModified(assets, fileName, S3, options, type, iter));
     } else {
       // Set the file name
+      var type = mime.lookup(assets);
       fileName = assets.substr(1);
-      position = fileName.lastIndexOf('.');
-      timestamp = fs.statSync(path.join(options.publicDir, assets)).mtime.getTime();
-      hash = hash.update(fs.readFileSync(path.join(options.publicDir, assets)));
-      fileName = _(fileName).splice(position, 0, '.' + hash.digest("hex"));
-      S3.headFile(encodeURIComponent(fileName), checkStringIfModified(assets, fileName, S3, options, timestamp, iter));
+
+      if (type !== 'text/css') {
+        position = fileName.lastIndexOf('.');
+        timestamp = fs.statSync(path.join(options.publicDir, assets)).mtime.getTime();
+        hash = hash.update(fs.readFileSync(path.join(options.publicDir, assets)));
+        fileName = _(fileName).splice(position, 0, '.' + hash.digest("hex"));
+        S3.headFile(encodeURIComponent(fileName), checkStringIfModified(assets, fileName, S3, options, timestamp, iter));
+      } else {
+        // Always upload css.
+        checkStringIfModified(assets, fileName, S3, options, timestamp, iter)(null, {});
+      }
+
     }
   }, function (err, results) {
     done(err, results);


### PR DESCRIPTION
Now you don't have to change selectors in your stylus files to regenerate the hashed css file.
