### PR TITLE
Fixed image extraction for css rules not followed by ';'

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -368,7 +368,7 @@ var checkStringIfModified = function(assets, fileName, S3, options, timestamp, c
             if (options.production) {
               console.log('Extracting images...');
 
-              body.replace(/(background\-image|background|content|border\-image)\:[^;]*url\((?!data:)['"]?([^\)'"]+)['"]?\)/g, function (match, attribute, url) {
+              body.replace(/(background\-image|background|content|border\-image)\:[^;\n]*url\((?!data:)['"]?([^\)'"]+)['"]?\)/g, function (match, attribute, url) {
                 var relativePath = url;
                 if ('/' === relativePath[0]) {
                   relativePath = relativePath.substr(1);
@@ -390,7 +390,7 @@ var checkStringIfModified = function(assets, fileName, S3, options, timestamp, c
             }
 
             async.parallel(imagesToUpload, function() {
-              body = body.replace(/(background\-image|background|content|border\-image)\:[^;]*url\((?!data:)['"]?([^\)'"]+)['"]?\)/g, function (match, attribute, url) {
+              body = body.replace(/(background\-image|background|content|border\-image)\:[^;\n]*url\((?!data:)['"]?([^\)'"]+)['"]?\)/g, function (match, attribute, url) {
                 return match.replace(url, images[url]);
               });
 


### PR DESCRIPTION
This fix didn't break stufff. #6 did. What happened is that I was replacing the hash value generated using non-transformed css (before the url()'s were replaced witht he onces from CDN). However createTag() was hashing stuff AGAIN using the non-transformed one.
