### PR TITLE
DEVOPS-3407 - Do not bother trying to upload image CSS attributes wit…

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -380,7 +380,11 @@ var checkStringIfModified = function(assets, fileName, S3, options, timestamp, c
                   relativePath = relativePath.substr(1);
                 }
 
-                if (!images[url]) {
+                /*
+                 If the image URL is absolute (starts with http/https), then don't bother trying to
+                 upload to S3 because it won't work, anyway.
+                 */
+                if (!images[url] && !/^http/.test(relativePath)) {
                   imagesToUpload.push(function(callback) {
                     return compile(relativePath, relativePath, S3, options, 
                       'image', 'image/' + path.extname(url).substr(1), Date.now(), function(hashedFileName) {


### PR DESCRIPTION
…h absolute URLs

https://jira.brandingbrand.com/browse/DEVOPS-3407

**MERGE WITH CAUTION - THIS AFFECTS ALL VERSIONS OF MIRAGE**

Issue:  If you use an absolute URL attribute in a compiled stylus file, the front-end server will crash when trying to upload the assets to S3.  
Example:  `background: url(http://www.maurices.com/images/rt_arrow_sm.gif) no-repeat 0 1px;`

https://github.com/brandingbrand/maurices.m/pull/450/files?w=1#diff-da2e9802563c947e8e83499701d44ae9R164

To fix this issue, simply check to see if the URL starts with `http`.  If it does, don't bother uploading.

The intended fix for this PR can be tested by checking out maurices dev01 FE/BE, checkout bb-mirage `v1.25.5-extra-css`, and checkout this PR.  You will need to `npm link` express-cdn into bb-mirage and bb-mirage into maurices.m.

Test URL:  http://localhost:3000/reviews/56700476/new