### PR TITLE
Fixed absolute image url processing in css

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -394,7 +394,7 @@ var checkStringIfModified = function(assets, fileName, S3, options, timestamp, c
                   });
                 }
 
-                images[url] = true;
+                images[url] = url;
                 return attribute + ':url(' + url + ')';
               }); // > /dev/null - we don't need this just yet
             }


### PR DESCRIPTION
**Ticket:** https://jira.brandingbrand.com/browse/

## Description
Fixed a bug that causes absolute image url in css file to be replaced with 'true' string
Discovered in: https://jira.brandingbrand.com/browse/LRM-2468?focusedCommentId=844770&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-844770


Original procedure:
1. extract source url
2. set target url to true (placeholder)
3. if source url  is not absolute, upload to cdn and update target url; if source url  is absolute, skip this step
4. replace source url with target url

New procedure:
1. extract source url
2. **set target url to source url (so if it is absolute, source url and target url are identical)**
3. if source url is not absolute, upload to cdn and update target url; if source url is absolute, skip this step
4. replace source url with target url
  

## Test

https://jira.brandingbrand.com/browse/LRM-2468 can be fixed if making this change

